### PR TITLE
Add bash aliases during the install function, update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ bash code.sh install
 ## 4. Start
 
 Start OpenVSCode Server:
+(You need to exec /bin/bash first!)
 ```bash
-bash code.sh
+vscode
 ```
 
 Open web preview URL:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start Google Cloud Shell:
 
 Download `code.sh` script:
 ```bash
-mkdir ~/OpenVSCode && cd ~/OpenVSCode && curl -O "https://raw.githubusercontent.com/Cyclenerd/google-cloud-shell-vscode/master/code.sh"
+cd ~ && curl -O "https://raw.githubusercontent.com/Cyclenerd/google-cloud-shell-vscode/master/code.sh"
 ```
 
 ## 3. Install

--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ COMMAND is one of the following:
         help    - displays help (this message)
 ```
 
-## Background Process
+## Background Process Management
 If you use aliases like:
 ```bash
-code
+code 
 ```
-the script will load in the background and return your cloud shell. You can use 'fg' to foreground the server job and kill it.  
+the script will load in the background and automatically return your cloud shell to a new line. 
+
+You can use 'fg' to foreground the server job or 'top' to manage the process as usual. 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start Google Cloud Shell:
 
 Download `code.sh` script:
 ```bash
-curl -O "https://raw.githubusercontent.com/Cyclenerd/google-cloud-shell-vscode/master/code.sh"
+mkdir ~/OpenVSCode && cd ~/OpenVSCode && curl -O "https://raw.githubusercontent.com/Cyclenerd/google-cloud-shell-vscode/master/code.sh"
 ```
 
 ## 3. Install

--- a/README.md
+++ b/README.md
@@ -84,11 +84,7 @@ COMMAND is one of the following:
 ```
 
 ## Background Process Management
-If you use aliases like:
-```bash
-code 
-```
-the script will load in the background and automatically return your cloud shell to a new line. 
+If you use aliases like 'code' or 'vscode' instead of 'bash code.sh' the script will load in the background and automatically return your cloud shell to a new line. 
 
 You can use 'fg' to foreground the server job or 'top' to manage the process as usual. 
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,6 @@ COMMAND is one of the following:
         help    - displays help (this message)
 ```
 
-## Background Process Management
-If you use aliases like 'code' or 'vscode' instead of 'bash code.sh' the script will load in the background and automatically return your cloud shell to a new line. 
-
-You can use 'fg' to foreground the server job or 'top' to manage the process as usual. 
-
 ## Contributing
 
 Have a patch that will benefit this project?

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start Google Cloud Shell:
 
 Download `code.sh` script:
 ```bash
-cd ~ && curl -O "https://raw.githubusercontent.com/Cyclenerd/google-cloud-shell-vscode/master/code.sh"
+curl -O "https://raw.githubusercontent.com/Cyclenerd/google-cloud-shell-vscode/master/code.sh"
 ```
 
 ## 3. Install
@@ -27,9 +27,8 @@ bash code.sh install
 ## 4. Start
 
 Start OpenVSCode Server:
-[The first time after you install, you will need to 'exec /bin/bash' to load aliases]
 ```bash
-code
+bash code.sh
 ```
 
 Open web preview URL:
@@ -62,15 +61,20 @@ Edit settings (<kbd>Ctrl</kbd> + <kbd>,</kbd>):
 }
 ```
 
+## Tip
+
+Add `code.sh` to your Bash aliases with absolute pathnames. You can then execute `code` anywhere.
+
+Alias (~/.bash_aliases):
+```text
+echo "bash `pwd`/code.sh" >> ~/.bash_aliases
+```
+
 ## Usage
 
 Help:
 ```bash
 bash code.sh help
-```
-or 
-```bash
-code help
 ```
 
 ```text

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ bash code.sh install
 ## 4. Start
 
 Start OpenVSCode Server:
-(You need to exec /bin/bash first!)
+[The first time after you install, you will need to 'exec /bin/bash' to load aliases. One time thing.]
 ```bash
-vscode
+code
 ```
 
 Open web preview URL:
@@ -68,6 +68,10 @@ Help:
 ```bash
 bash code.sh help
 ```
+or 
+```bash
+code help
+```
 
 ```text
 Usage: code.sh [COMMAND]
@@ -78,6 +82,13 @@ COMMAND is one of the following:
         remove  - remove OpenVSCode Server
         help    - displays help (this message)
 ```
+
+## Background Process
+If you use aliases like:
+```bash
+code
+```
+the script will load in the background and return your cloud shell. You can use 'fg' to foreground the server job and kill it.  
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bash code.sh install
 ## 4. Start
 
 Start OpenVSCode Server:
-[The first time after you install, you will need to 'exec /bin/bash' to load aliases. One time thing.]
+[The first time after you install, you will need to 'exec /bin/bash' to load aliases]
 ```bash
 code
 ```

--- a/code.sh
+++ b/code.sh
@@ -165,10 +165,10 @@ function install_openvscode() {
 		"$MY_OPENVSCODE_DIR/latest/bin/openvscode-server" --install-extension "$MY_OPENVSCODE_EXTENSION" --force
 	done
 
-	echo "alias code='bash ~/code.sh'" >> ~/.bashrc
-	
+	echo
+	echo "Tip: Add $ME to your Bash aliases with absolute pathnames. You can then execute $ME anywhere." 
+	echo
 	echo_success "Installed successfully. You can start OpenVSCode Server now."
-	echo 'You could type: "exec /bin/bash" to reload configs and then "code" to launch the server from your cloud shell.' 
 }
 
 function start_openvscode() {

--- a/code.sh
+++ b/code.sh
@@ -165,11 +165,10 @@ function install_openvscode() {
 		"$MY_OPENVSCODE_DIR/latest/bin/openvscode-server" --install-extension "$MY_OPENVSCODE_EXTENSION" --force
 	done
 
-	echo "alias code='bash code.sh&'" >> ~/.bashrc
-	echo "alias vscode='bash code.sh&'" >> ~/.bashrc
+	echo "alias code='bash code.sh'" >> ~/.bashrc
 	
 	echo_success "Installed successfully. You can start OpenVSCode Server now."
-	echo 'You could type: "exec /bin/bash" to reload configs and then "code" or "vscode" to launch the server from your cloud shell.' 
+	echo 'You could type: "exec /bin/bash" to reload configs and then "code" to launch the server from your cloud shell.' 
 }
 
 function start_openvscode() {

--- a/code.sh
+++ b/code.sh
@@ -165,7 +165,7 @@ function install_openvscode() {
 		"$MY_OPENVSCODE_DIR/latest/bin/openvscode-server" --install-extension "$MY_OPENVSCODE_EXTENSION" --force
 	done
 
-	echo "alias code='bash code.sh'" >> ~/.bashrc
+	echo "alias code='bash ~/code.sh'" >> ~/.bashrc
 	
 	echo_success "Installed successfully. You can start OpenVSCode Server now."
 	echo 'You could type: "exec /bin/bash" to reload configs and then "code" to launch the server from your cloud shell.' 

--- a/code.sh
+++ b/code.sh
@@ -164,8 +164,12 @@ function install_openvscode() {
 	for MY_OPENVSCODE_EXTENSION in "${MY_OPENVSCODE_EXTENSIONS[@]}"; do
 		"$MY_OPENVSCODE_DIR/latest/bin/openvscode-server" --install-extension "$MY_OPENVSCODE_EXTENSION" --force
 	done
+
+	echo "alias code='bash code.sh&'" >> ~/.bashrc
+	echo "alias vscode='bash code.sh&'" >> ~/.bashrc
 	
 	echo_success "Installed successfully. You can start OpenVSCode Server now."
+	echo 'You could type: "exec /bin/bash" to reload configs and then "code" or "vscode" to launch the server from your cloud shell.' 
 }
 
 function start_openvscode() {


### PR DESCRIPTION
Nice script! I'm using it but found it annoying to type 'bash ~/code.sh' as I worked around cloudshell and changed my directory, so I added an alias for 'code'  to .bashrc in the install process so I could access it in any tree. Updated documentation to match. (Note that the alias still requires the script to live in ~/ to work).